### PR TITLE
check sqlite3 version for pk column convention

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -3,6 +3,9 @@ import sqlite3
 from indexd.index.sqlite import SQLiteIndexDriver
 from indexd.alias.sqlite import SQLiteAliasDriver
 
+
+OLD_SQLITE = sqlite3.sqlite_version_info < (3, 7, 16)
+
 INDEX_HOST = 'index.sq3'
 ALIAS_HOST = 'alias.sq3'
 
@@ -15,12 +18,12 @@ INDEX_TABLES = {
     ],
     'records_hash': [
         (0, u'id', u'TEXT', 0, None, 1),
-        (1, u'type', u'TEXT', 0, None, 2),
+        (1, u'type', u'TEXT', 0, None, 1 if OLD_SQLITE else 2),
         (2, u'hash', u'TEXT', 0, None, 0),
     ],
     'records_urls': [
         (0, u'id', u'TEXT', 0, None, 1),
-        (1, u'url', u'TEXT', 0, None, 2),
+        (1, u'url', u'TEXT', 0, None, 1 if OLD_SQLITE else 2),
     ],
 }
 


### PR DESCRIPTION
Adds check for older versions of SQLite3 before performing testing. Specifically, before v3.7.16 the documentation surrounding the primary key column for the table_info pragma was not in place. This resulted in the pk column always being listed as 1 for columns that were part of the primary key. In later versions, it was specified that the pk column should list base-1 position of the column in regards to use in the primary key.