### PR TITLE
adds config errors

### DIFF
--- a/indexd/blueprint.py
+++ b/indexd/blueprint.py
@@ -173,5 +173,10 @@ def get_config(setup_state):
     config = setup_state.app.config
     index_config = config.get('INDEX', {})
     alias_config = config.get('ALIAS', {})
-    blueprint.index_driver = index_config['driver'](**index_config)
-    blueprint.alias_driver = alias_config['driver'](**alias_config)
+
+    try: blueprint.index_driver = index_config['driver'](**index_config)
+    except Exception as err:
+        raise errors.ConfigurationError(err)
+    try: blueprint.alias_driver = alias_config['driver'](**alias_config)
+    except Exception as err:
+        raise errors.ConfigurationError(err)

--- a/indexd/errors.py
+++ b/indexd/errors.py
@@ -14,3 +14,8 @@ class UserError(Exception):
     '''
     User error.
     '''
+
+class ConfigurationError(Exception):
+    '''
+    Configuration error.
+    '''

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1,0 +1,80 @@
+import flask
+import pytest
+
+import indexd
+from indexd import errors
+from indexd.index.sqlite import SQLiteIndexDriver
+from indexd.alias.sqlite import SQLiteAliasDriver
+
+
+INDEX_CONFIG = {
+    'driver': SQLiteIndexDriver,
+    'SQLITE3': {
+        'host': 'index.sq3',
+    }
+}
+
+ALIAS_CONFIG = {
+    'driver': SQLiteAliasDriver,
+    'SQLITE3': {
+        'host': 'alias.sq3',
+    }
+}
+
+
+def test_flask_blueprint():
+    '''
+    Tests standing up the server using flask.
+    '''
+    app = flask.Flask(__name__)
+
+    app.config['INDEX'] = INDEX_CONFIG
+    app.config['ALIAS'] = ALIAS_CONFIG
+
+    app.register_blueprint(indexd.blueprint)
+
+def test_flask_blueprint_missing_index_config():
+    '''
+    Tests standing up the server using flask without an index config.
+    '''
+    app = flask.Flask(__name__)
+
+    app.config['ALIAS'] = ALIAS_CONFIG
+
+    with pytest.raises(errors.ConfigurationError):
+        app.register_blueprint(indexd.blueprint)
+
+def test_flask_blueprint_invalid_index_config():
+    '''
+    Tests standing up the server using flask without an index config.
+    '''
+    app = flask.Flask(__name__)
+
+    app.config['INDEX'] = None
+    app.config['ALIAS'] = ALIAS_CONFIG
+
+    with pytest.raises(errors.ConfigurationError):
+        app.register_blueprint(indexd.blueprint)
+
+def test_flask_blueprint_missing_alias_config():
+    '''
+    Tests standing up the server using flask without an alias config.
+    '''
+    app = flask.Flask(__name__)
+
+    app.config['INDEX'] = INDEX_CONFIG
+
+    with pytest.raises(errors.ConfigurationError):
+        app.register_blueprint(indexd.blueprint)
+
+def test_flask_blueprint_invalid_alias_config():
+    '''
+    Tests standing up the server using flask without an alias config.
+    '''
+    app = flask.Flask(__name__)
+
+    app.config['INDEX'] = INDEX_CONFIG
+    app.config['ALIAS'] = None
+
+    with pytest.raises(errors.ConfigurationError):
+        app.register_blueprint(indexd.blueprint)


### PR DESCRIPTION
Adds custom configuration errors to blueprint. This ensures that any configuration error can be caught by catching the ```ConfigurationError``` exception type.