### PR TITLE
adds basic auth

### DIFF
--- a/bin/indexd
+++ b/bin/indexd
@@ -10,6 +10,7 @@ from indexd.index.blueprint import blueprint as indexd_index_blueprint
 from indexd.alias.blueprint import blueprint as indexd_alias_blueprint
 from indexd.blueprint import blueprint as cross_blueprint
 
+from indexd.auth.drivers.alchemy import SQLAlchemyAuthDriver
 from indexd.index.drivers.alchemy import SQLAlchemyIndexDriver
 from indexd.alias.drivers.alchemy import SQLAlchemyAliasDriver
 
@@ -36,6 +37,8 @@ def main(host, port, debug_flask=False, **kwargs):
     app.config['ALIAS'] = {
         'driver': SQLAlchemyAliasDriver('sqlite:///alias.sq3'),
     }
+
+    app.auth = SQLAlchemyAuthDriver('sqlite:///auth.sq3').auth
 
     app.register_blueprint(indexd_index_blueprint)
     app.register_blueprint(indexd_alias_blueprint)

--- a/indexd/alias/blueprint.py
+++ b/indexd/alias/blueprint.py
@@ -2,8 +2,8 @@ import re
 import flask
 import jsonschema
 
+from indexd.errors import AuthError
 from indexd.errors import UserError
-from indexd.errors import PermissionError
 
 from .schema import PUT_RECORD_SCHEMA
 from .schema import POST_RECORD_SCHEMA
@@ -156,8 +156,8 @@ def handle_multiple_records_error(err):
 def handle_user_error(err):
     return flask.jsonify(error=str(err)), 400
 
-@blueprint.errorhandler(PermissionError)
-def handle_permission_error(err):
+@blueprint.errorhandler(AuthError)
+def handle_auth_error(err):
     return flask.jsonify(error=str(err)), 403
 
 @blueprint.errorhandler(RevisionMismatch)

--- a/indexd/alias/blueprint.py
+++ b/indexd/alias/blueprint.py
@@ -2,6 +2,8 @@ import re
 import flask
 import jsonschema
 
+from indexd.auth import authorize
+
 from indexd.errors import AuthError
 from indexd.errors import UserError
 
@@ -95,6 +97,7 @@ def get_alias():
 #    return flask.jsonify(ret), 200
 
 @blueprint.route('/alias/<path:record>', methods=['PUT'])
+@authorize
 def put_alias_record(record):
     '''
     Create or replace an existing record.
@@ -132,6 +135,7 @@ def put_alias_record(record):
     return flask.jsonify(ret), 200
 
 @blueprint.route('/alias/<path:record>', methods=['DELETE'])
+@authorize
 def delete_alias_record(record):
     '''
     Delete an alias.

--- a/indexd/auth/__init__.py
+++ b/indexd/auth/__init__.py
@@ -1,0 +1,26 @@
+from functools import wraps
+
+from flask import request
+from flask import current_app
+
+from .errors import AuthError
+
+def authorize(f):
+    '''
+    Decorator for requiring auth.
+    Replaces the request authorization with a user context.
+    Raises AuthError if authorization fails.
+    '''
+    @wraps(f)
+    def check_auth(*args, **kwargs):
+        if not request.authorization:
+            raise AuthError('Username / password required.')
+        user = current_app.auth(
+            request.authorization.username,
+            request.authorization.password,
+        )
+        request.authorization = user
+
+        return f(*args, **kwargs)
+
+    return check_auth

--- a/indexd/auth/driver.py
+++ b/indexd/auth/driver.py
@@ -1,0 +1,17 @@
+import abc
+
+class AuthDriverABC(object):
+    '''
+    Auth Driver Abstract Base Class
+
+    Driver interface for authorization.
+    '''
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def auth(self, username, password):
+        '''
+        Returns a dict of user information.
+        Raises AuthError otherwise.
+        '''
+        raise NotImplementedError('TODO')

--- a/indexd/auth/drivers/alchemy.py
+++ b/indexd/auth/drivers/alchemy.py
@@ -1,0 +1,82 @@
+import json
+import uuid
+
+from contextlib import contextmanager
+
+from sqlalchemy import String
+from sqlalchemy import Column
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.orm.exc import MultipleResultsFound
+from sqlalchemy.ext.declarative import declarative_base
+
+from indexd import auth
+
+from indexd.auth.driver import AuthDriverABC
+
+from indexd.auth.errors import AuthError
+
+
+Base = declarative_base()
+
+class AuthRecord(Base):
+    '''
+    Base auth record representation.
+    '''
+    __tablename__ = 'auth_record'
+
+    username = Column(String, primary_key=True)
+    password = Column(String)
+
+class SQLAlchemyAuthDriver(AuthDriverABC):
+    '''
+    SQLAlchemy implementation of auth driver.
+    '''
+
+    def __init__(self, conn, **config):
+        '''
+        Initialize the SQLAlchemy database driver.
+        '''
+        self.engine = create_engine(conn, **config)
+        
+        Base.metadata.bind = self.engine
+        Base.metadata.create_all()
+        
+        self.Session = sessionmaker(bind=self.engine)
+
+    @property
+    @contextmanager
+    def session(self):
+        '''
+        Provide a transactional scope around a series of operations.
+        '''
+        session = self.Session()
+        
+        yield session
+        
+        try: session.commit()
+        except:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def auth(self, username, password):
+        '''
+        Returns a dict of user information.
+        Raises AutheError otherwise.
+        '''
+        with self.session as session:
+            query = session.query(AuthRecord)
+
+            # Select on username / password.
+            query = query.filter(AuthRecord.username == username)
+            query = query.filter(AuthRecord.password == password)
+
+            try: query.one()
+            except NoResultError as err:
+                raise AuthError('username / password mismatch')
+
+        # TODO return user information from records
+        return {}

--- a/indexd/auth/drivers/alchemy.py
+++ b/indexd/auth/drivers/alchemy.py
@@ -62,12 +62,19 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
         finally:
             session.close()
 
+    @staticmethod
+    def digest(password):
+        '''
+        Digests a string.
+        '''
+        return hashlib.sha256(password.encode('utf-8')).hexdigest()
+
     def auth(self, username, password):
         '''
         Returns a dict of user information.
         Raises AutheError otherwise.
         '''
-        password = hashlib.sha256(password).hexdigest()
+        password = self.digest(password)
         with self.session as session:
             query = session.query(AuthRecord)
 

--- a/indexd/auth/errors.py
+++ b/indexd/auth/errors.py
@@ -1,0 +1,4 @@
+class AuthError(Exception):
+    '''
+    Base auth error.
+    '''

--- a/indexd/blueprint.py
+++ b/indexd/blueprint.py
@@ -2,8 +2,8 @@ import re
 import flask
 import jsonschema
 
+from indexd.errors import AuthError
 from indexd.errors import UserError
-from indexd.errors import PermissionError
 
 
 blueprint = flask.Blueprint('cross', __name__)
@@ -45,8 +45,8 @@ def get_alias(alias):
 def handle_user_error(err):
     return flask.jsonify(error=str(err)), 400
 
-@blueprint.errorhandler(PermissionError)
-def handle_permission_error(err):
+@blueprint.errorhandler(AuthError)
+def handle_auth_error(err):
     return flask.jsonify(error=str(err)), 403
 
 @blueprint.record

--- a/indexd/errors.py
+++ b/indexd/errors.py
@@ -1,4 +1,4 @@
-from auth.errors import AuthError
+from .auth.errors import AuthError
 
 class UserError(Exception):
     '''

--- a/indexd/errors.py
+++ b/indexd/errors.py
@@ -1,7 +1,4 @@
-class PermissionError(Exception):
-    '''
-    Permission error.
-    '''
+from auth.errors import AuthError
 
 class UserError(Exception):
     '''

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -2,6 +2,8 @@ import re
 import flask
 import jsonschema
 
+from indexd.auth import authorize
+
 from indexd.errors import AuthError
 from indexd.errors import UserError
 
@@ -149,6 +151,7 @@ def get_index_record(record):
     return flask.jsonify(ret), 200
 
 @blueprint.route('/index/', methods=['POST'])
+@authorize
 def post_index_record():
     '''
     Create a new record.
@@ -177,6 +180,7 @@ def post_index_record():
     return flask.jsonify(ret), 200
 
 @blueprint.route('/index/<record>', methods=['PUT'])
+@authorize
 def put_index_record(record):
     '''
     Update an existing record.
@@ -209,6 +213,7 @@ def put_index_record(record):
     return flask.jsonify(ret), 200
 
 @blueprint.route('/index/<record>', methods=['DELETE'])
+@authorize
 def delete_index_record(record):
     '''
     Delete an existing sign.

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -2,8 +2,8 @@ import re
 import flask
 import jsonschema
 
+from indexd.errors import AuthError
 from indexd.errors import UserError
-from indexd.errors import PermissionError
 
 from .schema import PUT_RECORD_SCHEMA
 from .schema import POST_RECORD_SCHEMA
@@ -233,8 +233,8 @@ def handle_multiple_records_error(err):
 def handle_user_error(err):
     return flask.jsonify(error=str(err)), 400
 
-@blueprint.errorhandler(PermissionError)
-def handle_permission_error(err):
+@blueprint.errorhandler(AuthError)
+def handle_auth_error(err):
     return flask.jsonify(error=str(err)), 403
 
 @blueprint.errorhandler(RevisionMismatch)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ setup(
     version='0.1',
     packages=[
         'indexd',
+        'indexd.auth',
+        'indexd.auth.drivers',
         'indexd.index',
         'indexd.index.drivers',
         'indexd.alias',

--- a/tests/test_driver_alchemy_auth.py
+++ b/tests/test_driver_alchemy_auth.py
@@ -1,0 +1,84 @@
+import sqlite3
+import hashlib
+
+import pytest
+
+import util
+
+from indexd.errors import AuthError
+
+from indexd.auth.drivers.alchemy import SQLAlchemyAuthDriver
+
+
+USERNAME = 'abc'
+PASSWORD = '123'
+DIGESTED = hashlib.sha256(PASSWORD).hexdigest()
+
+# TODO check if pytest has utilities for meta-programming of tests
+
+@util.removes('auth.sq3')
+def test_driver_init_does_not_create_records():
+    '''
+    Tests for creation of records after driver init.
+    Tests driver init does not have unexpected side-effects.
+    '''
+    driver = SQLAlchemyAuthDriver('sqlite:///auth.sq3')
+        
+    with sqlite3.connect('auth.sq3') as conn:
+        
+        count = conn.execute('''
+            SELECT COUNT(*) FROM auth_record
+        ''').fetchone()[0]
+        
+        assert count == 0, 'driver created records upon initilization'
+
+@util.removes('auth.sq3')
+def test_driver_auth_accepts_good_creds():
+    '''
+    Tests driver accepts good creds.
+    '''
+    driver = SQLAlchemyAuthDriver('sqlite:///auth.sq3')
+
+    with sqlite3.connect('auth.sq3') as conn:
+
+        conn.execute('''
+            INSERT INTO auth_record VALUES (?,?)
+        ''', (USERNAME, DIGESTED))
+        
+    driver.auth(USERNAME, PASSWORD)
+
+@util.removes('auth.sq3')
+def test_driver_auth_rejects_bad_creds():
+    '''
+    Test driver rejects bad creds.
+    '''
+    driver = SQLAlchemyAuthDriver('sqlite:///auth.sq3')
+
+    with sqlite3.connect('auth.sq3') as conn:
+
+        conn.execute('''
+            INSERT INTO auth_record VALUES (?, ?)
+        ''', (USERNAME, DIGESTED))
+
+    with pytest.raises(AuthError):
+        driver.auth(USERNAME, 'invalid_'+PASSWORD)
+
+    with pytest.raises(AuthError):
+        driver.auth('invalid_'+USERNAME, PASSWORD)
+
+@util.removes('auth.sq3')
+def test_driver_auth_returns_user_context():
+    '''
+    Tests driver accepts good creds.
+    '''
+    driver = SQLAlchemyAuthDriver('sqlite:///auth.sq3')
+
+    with sqlite3.connect('auth.sq3') as conn:
+
+        conn.execute('''
+            INSERT INTO auth_record VALUES (?,?)
+        ''', (USERNAME, DIGESTED))
+        
+    user = driver.auth(USERNAME, PASSWORD)
+
+    assert user is not None, 'user context was None'

--- a/tests/test_driver_alchemy_auth.py
+++ b/tests/test_driver_alchemy_auth.py
@@ -12,7 +12,7 @@ from indexd.auth.drivers.alchemy import SQLAlchemyAuthDriver
 
 USERNAME = 'abc'
 PASSWORD = '123'
-DIGESTED = hashlib.sha256(PASSWORD).hexdigest()
+DIGESTED = SQLAlchemyAuthDriver.digest(PASSWORD)
 
 # TODO check if pytest has utilities for meta-programming of tests
 


### PR DESCRIPTION
This adds basic auth to all data-modifying endpoints. This is done by implementing `indexd.auth.driver.AuthDriverABC` abstract base class, similar to the index and alias drivers, and registering functions as requiring auth via the `indexd.auth.authorize` decorator. Requests routed to handlers wrapped in the `authorize` decorator will be authenticated using the username and password in `flask.request.authorization`. If authenticated, the `flask.request.authorization` property will be replaced with a user context dictionary that provides user privilege information, such as username and roles.

Currently there is no way to create, modify or delete credentials. Credentials must be handled directly in the auth backend database. This should be handled via a separate pull request to add `/auth` endpoints.