### PR TITLE
fix(url-query): fix join query

### DIFF
--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -146,7 +146,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             for h,v in hashes.items():
                 # Select subset that matches given hash.
                 sub = session.query(IndexRecordUrl)
-                sub = sub.join(IndexRecord.hashes)
+                sub = sub.join(IndexRecordUrl.index_record).join(IndexRecord.hashes)
                 sub = sub.filter(and_(
                     IndexRecordHash.hash_type == h,
                     IndexRecordHash.hash_value == v,


### PR DESCRIPTION
the previous join only joined on index_record and index_record_hash table, actually didn't filter out index_record_url by hashes
previous query:
```
print index_s.query(IndexRecordUrl).join(IndexRecord.hashes).filter(and_(Inde
xRecordHash.hash_value=='f787197cffb8ee0e9e4f061b89b61a07'))
SELECT index_record_url.did AS index_record_url_did, index_record_url.url AS index_record_url_url 
FROM index_record_url, index_record JOIN index_record_hash ON index_record.did = index_record_hash.did 
WHERE index_record_hash.hash_value = %(hash_value_1)s
```
current query:
```
print index_s.query(IndexRecordUrl).join(IndexRecordUrl.index_record).join(In
dexRecord.hashes).filter(and_(IndexRecordHash.hash_value=='f787197cffb8ee0e9e4f061b89b
61a07'))
SELECT index_record_url.did AS index_record_url_did, index_record_url.url AS index_record_url_url 
FROM index_record_url JOIN index_record ON index_record.did = index_record_url.did JOIN index_record_hash ON index_record.did = index_record_hash.did 
WHERE index_record_hash.hash_value = %(hash_value_1)s
```
r? @MurphyMarkW 