### PR TITLE
fix(sqlite): create sqlite file on docker start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER CDIS <cdissupport@opensciencedatacloud.org>
 
-RUN apt-get update && apt-get install -y python-pip git python-dev libpq-dev apache2 libapache2-mod-wsgi vim \ 
+RUN apt-get update && apt-get install -y sudo python-pip git python-dev libpq-dev apache2 libapache2-mod-wsgi vim \ 
  && apt-get clean && apt-get autoremove \
  && rm -rf /var/lib/apt/lists/*
 ADD . /indexd

--- a/dockerrun.bash
+++ b/dockerrun.bash
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 sed -i.bak -e 's/WSGIDaemonProcess indexd processes=1 threads=3/WSGIDaemonProcess indexd processes='${WSGI_PROCESSES:-1}' threads='${WSGI_THREADS:-3}'/g' /etc/apache2/sites-available/apache-indexd.conf
+cd /var/www/indexd; sudo -u www-data python wsgi.py
 /usr/sbin/apache2ctl -D FOREGROUND


### PR DESCRIPTION
This is a problem with docker's apache2 setup & default sqlite db file.
apache2 uses www-data as the default user for wsgi process, it then imports libraries on first request. So sqlite db files are created by www-data on first request.
But if you execute index_admin.py as another user before wsgi process, it will create db files under this user, making wsgi process unable to write to the sqlite file.

This calls wsgi.py onload to make sure everything is loaded and database  is touched